### PR TITLE
fix: 기본 정보 반환 feat: 취향 분석 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
     buildFeatures {
         dataBinding = true
+        viewBinding = true
     }
 
     defaultConfig {
@@ -63,8 +64,18 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("com.squareup.okhttp3:logging-interceptor:4.9.3")
     implementation("com.google.code.gson:gson:2.10.1")
+    implementation ("com.github.PhilJay:MPAndroidChart:v3.1.0")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    // Glide
+    implementation("com.github.bumptech.glide:glide:4.15.1")
+    annotationProcessor("com.github.bumptech.glide:compiler:4.15.1")
+    // Retrofit
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+    // 원형 시각화를 위한 MPAndroidChart 설치
+    implementation("com.github.PhilJay:MPAndroidChart:v3.1.0")
+
 }

--- a/app/src/main/java/com/example/docent/ApiService.kt
+++ b/app/src/main/java/com/example/docent/ApiService.kt
@@ -13,18 +13,21 @@ import com.google.gson.JsonObject
 
 interface ApiService {
     @Multipart
+
     @POST("artworks/upload/") // Django 서버의 이미지 업로드 엔드포인트
     fun uploadArtwork(
         @Part image: MultipartBody.Part
-    ): Call<RetrofitClient.ArtworkResponse> // Mock 데이터 (artwork_name과 artist)를 반환
-
+    ): Call<RetrofitClient.ArtworkResponse>
 
     @Streaming
     @POST("api/chat/") // SSE 지원하는 단일 API
     fun sendChatMessage(@Body payload: JsonObject): Call<ResponseBody>
 
+    // 사용자 취향 분석 API
+    @POST("artworks/analyze-preference/")
+    fun analyzePreference(@Body request: PreferenceRequest): Call<PreferenceResponse>
+
+    @GET("artworks/random/")
+    fun getRandomArtworks(): Call<List<Artwork>>}
 
 
-    @GET("artworks/upload/") // Dj0ango 서버의 Mock 데이터 반환 엔드포인트
-    fun getMockArtwork(): Call<Map<String, String>> // artwork_name과 artist를 반환
-}

--- a/app/src/main/java/com/example/docent/Artwork.kt
+++ b/app/src/main/java/com/example/docent/Artwork.kt
@@ -1,0 +1,8 @@
+package com.example.docent
+
+data class Artwork (
+    val id: Int,
+    val title: String,
+    val description: String,
+    val image_url: String
+)

--- a/app/src/main/java/com/example/docent/CameraActivity.kt
+++ b/app/src/main/java/com/example/docent/CameraActivity.kt
@@ -82,8 +82,6 @@ class CameraActivity : AppCompatActivity() {
             takePhoto()
         }
 
-        // Mock 데이터 호출 테스트
-        //fetchMockData()
     }
 
     private fun requestCameraPermission() {
@@ -149,18 +147,6 @@ class CameraActivity : AppCompatActivity() {
 
                     uploadImageToServer(photoFile)
 
-                    // 1) 카메라 unbind
-                    val cameraProviderFuture = ProcessCameraProvider.getInstance(this@CameraActivity)
-                    cameraProviderFuture.addListener({
-                        val cameraProvider = cameraProviderFuture.get()
-                        cameraProvider.unbindAll()
-
-                        // 2) 다음 액티비티로 이동 후 finish
-                        val intent = Intent(this@CameraActivity, ChatActivity::class.java).apply {
-                            putExtra("imageUri", savedUri.toString())
-                        }
-                        finish()
-                    }, ContextCompat.getMainExecutor(this@CameraActivity))
                 }
 
                 override fun onError(exception: ImageCaptureException) {
@@ -185,16 +171,16 @@ class CameraActivity : AppCompatActivity() {
                 if (response.isSuccessful) {
                     val data = response.body()
                     if (data != null) {
-                        Log.d("CameraActivity", "서버 응답 데이터: 제목=${data.title}, 작가=${data.artist}, 연도=${data.year}, 스타일=${data.style}, 설명=${data.description}")
+                        Log.d("CameraActivity", "서버 응답 데이터: 제목=${data.artwork_name}, 작가=${data.artist}, 연도=${data.year}, 설명=${data.description}")
                         // UI 업데이트 (예: 텍스트뷰 업데이트)
                         // exampleTextView.text = "작품 제목: ${data.title}\n작가: ${data.artist}"
 
                         // ChatActivity로 서버 응답 데이터 전달
                         val intent = Intent(this@CameraActivity, ChatActivity::class.java).apply {
                             putExtra("description", data.description)
-                            putExtra("title", data.title)
+                            putExtra("title", data.artwork_name)
                             putExtra("artist", data.artist)
-                            putExtra("year", data.year.toString())
+                            putExtra("year", data.year)
                         }
                         startActivity(intent)
                         finish()
@@ -214,23 +200,6 @@ class CameraActivity : AppCompatActivity() {
 
 
 
-    private fun fetchMockData() {
-        val apiService = RetrofitClient.instance
-        apiService.getMockArtwork().enqueue(object : Callback<Map<String, String>> {
-            override fun onResponse(call: Call<Map<String, String>>, response: Response<Map<String, String>>) {
-                if (response.isSuccessful) {
-                    val data = response.body()
-                    Log.d("CameraActivity", "Mock Data: $data")
-                } else {
-                    Log.e("CameraActivity", "Mock Data Error: ${response.code()}")
-                }
-            }
-
-            override fun onFailure(call: Call<Map<String, String>>, t: Throwable) {
-                Log.e("CameraActivity", "Mock Data Failure: ${t.message}")
-            }
-        })
-    }
 
     override fun onDestroy() {
         super.onDestroy()

--- a/app/src/main/java/com/example/docent/ChatActivity.kt
+++ b/app/src/main/java/com/example/docent/ChatActivity.kt
@@ -56,7 +56,8 @@ class ChatActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         val title = intent.getStringExtra("title") ?: "제목 없음"
         val artist = intent.getStringExtra("artist") ?: "작가 정보 없음"
         val year = intent.getStringExtra("year") ?: "연도 정보 없음"
-        val style = intent.getStringExtra("style") ?: "스타일 정보 없음"
+
+        Log.d("ChatActivity", "📦 인텐트로 전달된 데이터 - 제목=$title, 작가=$artist, 연도=$year, 설명=$description")
 
         if (messages.isEmpty()) {
             val initialMessage = """
@@ -69,9 +70,12 @@ class ChatActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
                 $description
             """.trimIndent()
 
-            messages.add(ChatMessage(initialMessage, false))
-            chatAdapter.notifyItemInserted(messages.size - 1)
-            chatRecyclerView.scrollToPosition(messages.size - 1)
+            runOnUiThread {
+                messages.add(ChatMessage(initialMessage, false)) // 챗봇 메시지로 추가
+                chatAdapter.notifyItemInserted(messages.size - 1) // UI 업데이트
+                chatRecyclerView.scrollToPosition(messages.size - 1) // 화면 아래로 스크롤
+            }
+
         }
 
         speechBtn.setOnClickListener {

--- a/app/src/main/java/com/example/docent/Keyword1Activity.kt
+++ b/app/src/main/java/com/example/docent/Keyword1Activity.kt
@@ -1,54 +1,123 @@
 package com.example.docent
-
 import android.content.Intent
 import android.os.Bundle
-import android.widget.Button
+import android.util.Log
 import android.widget.ImageView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-
+import com.bumptech.glide.Glide
+import com.example.docent.databinding.ActivityKeyword1Binding
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 class Keyword1Activity : AppCompatActivity() {
 
+    private lateinit var binding: ActivityKeyword1Binding
+    private lateinit var imageViews: List<ImageView>
+    private lateinit var artworks: List<Artwork>
+    private val selectedArtworkIds = mutableListOf<Int>()
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_keyword1)
+        binding = ActivityKeyword1Binding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        // Setting up a common method to handle button clicks
+        // ImageView 4개 연결
+        imageViews = listOf(
+            binding.artwork1, binding.artwork2, binding.artwork3, binding.artwork4
+        )
 
-        // 작품 추천 화면으로 이동
-        val next = findViewById<Button>(R.id.next6)
-        next.setOnClickListener {
-            val intent = Intent(this, ArtRecommendationActivity::class.java)
-            startActivity(intent)
+        // 이미지 로드
+        loadRandomArtworks()
+
+        // 다음 버튼 눌렀을 때 서버 전송
+        binding.next6.setOnClickListener {
+            if (selectedArtworkIds.isNotEmpty()) {
+                val preferenceRequest = PreferenceRequest(
+                    user_id = "user_123", // 로그인 연동 시 수정
+                    artwork_ids = selectedArtworkIds
+                )
+
+                RetrofitClient.instance.analyzePreference(preferenceRequest).enqueue(object : Callback<PreferenceResponse> {
+                    override fun onResponse(call: Call<PreferenceResponse>, response: Response<PreferenceResponse>) {
+                        if (response.isSuccessful) {
+                            val intent = Intent(this@Keyword1Activity, MypageActivity::class.java)
+                            intent.putIntegerArrayListExtra("selected_artwork_ids", ArrayList(selectedArtworkIds))
+                            startActivity(intent)
+                        } else {
+                            Toast.makeText(this@Keyword1Activity, "서버 응답 실패: ${response.code()}", Toast.LENGTH_SHORT).show()
+                        }
+                    }
+
+                    override fun onFailure(call: Call<PreferenceResponse>, t: Throwable) {
+                        Toast.makeText(this@Keyword1Activity, "서버 연결 실패: ${t.message}", Toast.LENGTH_SHORT).show()
+                    }
+                })
+            } else {
+                Toast.makeText(this@Keyword1Activity, "하나 이상의 작품을 선택하세요.", Toast.LENGTH_SHORT).show()
+            }
         }
 
-        val artwork1Image = findViewById<ImageView>(R.id.artwork1)
-        artwork1Image.setOnClickListener {
-            val intent = Intent(this, ArtRecommendationActivity::class.java)
-            startActivity(intent)
-            finish()
-        }
+    }
 
-        val artwork2Image = findViewById<ImageView>(R.id.artwork2)
-        artwork2Image.setOnClickListener {
-            val intent = Intent(this, ArtRecommendationActivity::class.java)
-            startActivity(intent)
-            finish()
-        }
+    private fun loadRandomArtworks() {
+        val api = RetrofitClient.instance
 
-        val artwork3Image = findViewById<ImageView>(R.id.artwork3)
-        artwork3Image.setOnClickListener {
-            val intent = Intent(this, ArtRecommendationActivity::class.java)
-            startActivity(intent)
-            finish()
-        }
+        api.getRandomArtworks().enqueue(object : Callback<List<Artwork>> {
+            override fun onResponse(
+                call: Call<List<Artwork>>,
+                response: Response<List<Artwork>>
+            ) {
+                if (response.isSuccessful) {
+                    artworks = response.body() ?: emptyList()
 
-        val artwork4Image = findViewById<ImageView>(R.id.artwork4)
-        artwork4Image.setOnClickListener {
-            val intent = Intent(this, ArtRecommendationActivity::class.java)
-            startActivity(intent)
-            finish()
+                    if (artworks.size >= 4) {
+                        for (i in 0 until 4) {
+                            val imageUrl = convertGoogleDriveUrl(artworks[i].image_url)
+                            Glide.with(this@Keyword1Activity)
+                                .load(imageUrl)
+                                .into(imageViews[i])
+
+                            imageViews[i].setOnClickListener {
+                                val artworkId = artworks[i].id
+
+                                if (selectedArtworkIds.contains(artworkId)) {
+                                    selectedArtworkIds.remove(artworkId)
+                                    imageViews[i].alpha = 1.0f // 선택 해제 시 원래 투명도
+                                } else {
+                                    selectedArtworkIds.add(artworkId)
+                                    imageViews[i].alpha = 0.5f // 선택 시 흐리게 표시
+                                }
+                            }
+
+                        }
+                    } else {
+                        Toast.makeText(this@Keyword1Activity, "작품이 충분하지 않습니다.", Toast.LENGTH_SHORT).show()
+                    }
+                } else {
+                    Log.e("Keyword1", "응답 실패: ${response.code()}")
+                }
+            }
+
+            override fun onFailure(call: Call<List<Artwork>>, t: Throwable) {
+                Log.e("Keyword1", "작품 불러오기 실패: ${t.message}")
+            }
+        })
+    }
+
+    // 🔄 구글 드라이브 URL 변환 함수
+    private fun convertGoogleDriveUrl(originalUrl: String): String {
+        val regex = Regex("id=([a-zA-Z0-9_-]+)")
+        val match = regex.find(originalUrl)
+        val fileId = match?.groupValues?.get(1)
+        return if (fileId != null) {
+            "https://drive.google.com/uc?export=view&id=$fileId"
+        } else {
+            originalUrl // 변환 실패 시 원본 URL 그대로 사용
         }
     }
 
-    }
+
+}

--- a/app/src/main/java/com/example/docent/LoginActivity.kt
+++ b/app/src/main/java/com/example/docent/LoginActivity.kt
@@ -23,10 +23,10 @@ class LoginActivity : AppCompatActivity() {
             insets
         }
 
-        // 로그인 버튼 클릭 시 취향분석 화면으로 전환
+        // 로그인 버튼 클릭 시 작품 추천 화면으로 전환
         val loginButton: Button = findViewById(R.id.login)
         loginButton.setOnClickListener {
-            val intent = Intent(this, PreferenceanalysisActivity::class.java)
+            val intent = Intent(this, ArtRecommendationActivity::class.java)
             startActivity(intent)
         }
 

--- a/app/src/main/java/com/example/docent/MypageActivity.kt
+++ b/app/src/main/java/com/example/docent/MypageActivity.kt
@@ -1,69 +1,179 @@
 package com.example.docent
 
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
+import android.util.Log
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import com.github.mikephil.charting.charts.PieChart
+import com.github.mikephil.charting.data.*
+import com.github.mikephil.charting.formatter.PercentFormatter
+import com.github.mikephil.charting.utils.ColorTemplate
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import com.example.docent.PreferenceRequest
+import com.example.docent.PreferenceResponse
+
 
 class MypageActivity : AppCompatActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_mypage)
 
+        val pieChart: PieChart = findViewById(R.id.pieChart)
 
-        val ticketImage = findViewById<ImageView>(R.id.ticket)
-        ticketImage.setOnClickListener {
-            val intent = Intent(this, exhibitionviewingActivity::class.java)
-            startActivity(intent)
+
+
+        // PieChart 기본 설정
+        pieChart.description.isEnabled = false
+        pieChart.setUsePercentValues(true)
+        pieChart.setEntryLabelTextSize(12f)
+        pieChart.setEntryLabelColor(Color.BLACK)
+        pieChart.setCenterText("")
+        pieChart.setCenterTextSize(18f)
+        pieChart.legend.isEnabled = false
+        pieChart.isDrawHoleEnabled = false
+
+        pieChart.setNoDataText("")         // 텍스트 없애기
+        pieChart.setNoDataTextColor(Color.TRANSPARENT) // 색상도 투명하게
+
+
+        val selectedArtworkIds = intent.getIntegerArrayListExtra("selected_artwork_ids") ?: listOf()
+
+
+        val preferenceRequest = PreferenceRequest(
+            user_id = "user_123", // 고정된 ID 또는 로그인 연동 시 유동적으로
+            artwork_ids = selectedArtworkIds
+        )
+
+        RetrofitClient.instance.analyzePreference(preferenceRequest)
+            .enqueue(object : Callback<PreferenceResponse> {
+                override fun onResponse(
+                    call: Call<PreferenceResponse>,
+                    response: Response<PreferenceResponse>
+                ) {
+                    if (response.isSuccessful) {
+                        val result = response.body()
+                        if (result != null) {
+                            val entries = mutableListOf<PieEntry>()
+                            result.topTags.forEach { tag ->
+                                entries.add(PieEntry(1f, tag))  // 퍼센트 대신 동일 값으로 설정
+                            }
+                            // 결과 저장
+                            saveTagsToPreferences(result.topTags)
+                            showPieChart(pieChart, entries)
+                        } else {
+                            // 응답은 성공했지만 결과가 비어있을 경우 → 저장된 태그 불러오기
+                            loadAndShowSavedTags(pieChart)
+                        }
+
+                    } else {
+                        // 응답은 성공했지만 결과가 비어있을 경우 -> 저장된 태그 불러오기
+                        Log.e("Mypage", "서버 응답 오류: ${response.code()}")
+                        loadAndShowSavedTags(pieChart)
+                    }
+                }
+
+                override fun onFailure(call: Call<PreferenceResponse>, t: Throwable) {
+                    Log.e("Mypage", "분석 실패: ${t.message}")
+                    // ✅ 서버 연결 실패 시 → 저장된 태그 불러오기
+                    loadAndShowSavedTags(pieChart)
+                }
+            })
+
+
+
+
+        //  아래는 기존 네비게이션 코드 유지
+        findViewById<ImageView>(R.id.ticket).setOnClickListener {
+            startActivity(Intent(this, exhibitionviewingActivity::class.java))
             finish()
         }
 
-        val heartImage = findViewById<ImageView>(R.id.heart)
-        heartImage.setOnClickListener {
-            val intent = Intent(this, GoodexhibitionActivity::class.java)
-            startActivity(intent)
+        findViewById<ImageView>(R.id.heart).setOnClickListener {
+            startActivity(Intent(this, GoodexhibitionActivity::class.java))
             finish()
         }
 
-        val logoutText: TextView = findViewById(R.id.logout)
-        logoutText.setOnClickListener {
-            val intent = Intent(this, LoginActivity::class.java)
-            startActivity(intent)
+        findViewById<TextView>(R.id.logout).setOnClickListener {
+            startActivity(Intent(this, LoginActivity::class.java))
         }
 
-        val museumImage = findViewById<ImageView>(R.id.museum)
-        museumImage.setOnClickListener {
-            val intent = Intent(this, ArtRecommendationActivity::class.java)
-            startActivity(intent)
+        findViewById<ImageView>(R.id.museum).setOnClickListener {
+            startActivity(Intent(this, ArtRecommendationActivity::class.java))
             finish()
         }
 
-        val chatImage = findViewById<ImageView>(R.id.chat)
-        chatImage.setOnClickListener {
-            val intent = Intent(this, ChathistoryActivity::class.java)
-            startActivity(intent)
+        findViewById<ImageView>(R.id.chat).setOnClickListener {
+            startActivity(Intent(this, ChathistoryActivity::class.java))
             finish()
         }
-        val cameraButton = findViewById<ImageView>(R.id.Camera_Button)
-        cameraButton.setOnClickListener {
+
+        findViewById<ImageView>(R.id.Camera_Button).setOnClickListener {
             startActivity(Intent(this, CameraActivity::class.java))
         }
 
-        // 커뮤니티 화면으로 이동
-        val comuButton = findViewById<ImageView>(R.id.Commu_Button)
-        comuButton.setOnClickListener {
-            val intent = Intent(this, communityActivity::class.java)
-            startActivity(intent)
+        findViewById<ImageView>(R.id.Commu_Button).setOnClickListener {
+            startActivity(Intent(this, communityActivity::class.java))
         }
 
-        // 커뮤니티 화면으로 이동
-        val settingButton = findViewById<ImageView>(R.id.setting)
-        settingButton.setOnClickListener {
-            val intent = Intent(this, SettingActivity::class.java)
-            startActivity(intent)
+        findViewById<ImageView>(R.id.setting).setOnClickListener {
+            startActivity(Intent(this, SettingActivity::class.java))
         }
 
+        findViewById<TextView>(R.id.preferenceanalysis).setOnClickListener {
+            startActivity(Intent(this, PreferenceanalysisActivity::class.java))
+        }
     }
+
+    // 🔧 PieChart 출력 함수
+    private fun showPieChart(pieChart: PieChart, entries: List<PieEntry>) {
+        val dataSet = PieDataSet(entries, "취향 분석")
+
+        // ✨ 차분한 톤의 색상으로 표현
+        dataSet.setColors(
+            Color.rgb(179, 205, 224), // 연한 하늘색
+            Color.rgb(251, 180, 174), // 부드러운 연분홍
+            Color.rgb(204, 235, 197), // 연한 민트
+            Color.rgb(222, 203, 228), // 연보라
+            Color.rgb(254, 217, 166)  // 살구색
+        )
+
+        val data = PieData(dataSet)
+        data.setDrawValues(false)
+        pieChart.data = data
+        pieChart.invalidate()
+    }
+
+    // 🔐 저장 함수
+    private fun saveTagsToPreferences(tags: List<String>) {
+        val prefs = getSharedPreferences("preference_tags", MODE_PRIVATE)
+        val editor = prefs.edit()
+        editor.putString("tags", tags.joinToString(","))
+        editor.apply()
+    }
+
+    // 📤 불러오기 함수
+    private fun loadTagsFromPreferences(): List<String> {
+        val prefs = getSharedPreferences("preference_tags", MODE_PRIVATE)
+        val savedString = prefs.getString("tags", "") ?: ""
+        return if (savedString.isNotEmpty()) savedString.split(",") else emptyList()
+    }
+
+    // 🎯 저장된 태그 불러와서 원형 그래프에 보여주는 함수
+    private fun loadAndShowSavedTags(pieChart: PieChart) {
+        val savedTags = loadTagsFromPreferences()
+        if (savedTags.isNotEmpty()) {
+            val entries = savedTags.map { PieEntry(1f, it) } // 퍼센트 없이 동일한 값
+            showPieChart(pieChart, entries)
+        }
+    }
+
+
+
 
 }

--- a/app/src/main/java/com/example/docent/PreferenceRequest.kt
+++ b/app/src/main/java/com/example/docent/PreferenceRequest.kt
@@ -1,0 +1,6 @@
+package com.example.docent
+
+data class PreferenceRequest (
+    val user_id: String,
+    val artwork_ids: List<Int>
+)

--- a/app/src/main/java/com/example/docent/PreferenceResponse.kt
+++ b/app/src/main/java/com/example/docent/PreferenceResponse.kt
@@ -1,0 +1,8 @@
+package com.example.docent
+
+import com.google.gson.annotations.SerializedName
+
+data class PreferenceResponse (
+    @SerializedName("top_tags")
+    val topTags: List<String>
+)

--- a/app/src/main/java/com/example/docent/PreferenceanalysisActivity.kt
+++ b/app/src/main/java/com/example/docent/PreferenceanalysisActivity.kt
@@ -20,7 +20,7 @@ class PreferenceanalysisActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
-        // 다음 버튼 클릭 시 로그인으로 전환
+        // 다음 버튼 클릭 시 작품 선택 창으로 전환
         val nextButton: Button = findViewById(R.id.next4)
         nextButton.setOnClickListener {
             val intent = Intent(this, Keyword1Activity::class.java)
@@ -28,12 +28,6 @@ class PreferenceanalysisActivity : AppCompatActivity() {
 
         }
 
-        // 작품 추천 화면으로 이동
-        val no = findViewById<TextView>(R.id.no)
-        no.setOnClickListener {
-            val intent = Intent(this, ArtRecommendationActivity::class.java)
-            startActivity(intent)
-        }
 
 
     }

--- a/app/src/main/java/com/example/docent/RetrofitClient.kt
+++ b/app/src/main/java/com/example/docent/RetrofitClient.kt
@@ -6,7 +6,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitClient {
-    private const val BASE_URL = "http://192.168.0.173:8000/" // Django 서버 주소
+    private const val BASE_URL = "http://192.168.219.106:8000/" // Django 서버 주소
     //    private const val BASE_URL = "https://b869-218-154-254-94.ngrok-free.app/"
     private val client: OkHttpClient by lazy {
         val logging = HttpLoggingInterceptor().apply {
@@ -18,7 +18,7 @@ object RetrofitClient {
     }
     val instance: ApiService by lazy {
         Retrofit.Builder()
-            .baseUrl("http://192.168.0.173:8000/")
+            .baseUrl("http://192.168.219.106:8000/")
             .client(client)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
@@ -26,10 +26,10 @@ object RetrofitClient {
     }
 
     data class ArtworkResponse(
-        val title: String,
+        val artwork_id: Int,
+        val artwork_name: String,
         val artist: String,
-        val year: Int,
-        val style: String,
+        val year: String,
         val description: String
     )
 }

--- a/app/src/main/res/layout/activity_keyword1.xml
+++ b/app/src/main/res/layout/activity_keyword1.xml
@@ -1,74 +1,92 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical"
-    android:id="@+id/main"
-    package="com.example.yourapp">
+    android:background="@color/white"
+    android:gravity="center_horizontal"
+    android:padding="24dp">
 
-
+    <!-- 안내 텍스트 -->
     <TextView
-        android:layout_width="match_parent"
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="40dp"
-        android:gravity="center"
         android:text="관심 있는 그림을 골라주세요."
-        android:textSize="18dp"
-        android:textStyle="bold">
-    </TextView>
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:textColor="#000000"
+        android:layout_marginBottom="24dp" />
 
-<LinearLayout
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    <!-- 이미지 4개를 담을 컨테이너 -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center">
 
-    <ImageView
-        android:id="@+id/artwork1"
-        android:layout_width="159dp"
-        android:layout_height="222dp"
-        android:layout_marginLeft="25dp"
-        android:layout_marginTop="85dp"
-        android:src="@drawable/vangoghart" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center">
 
-    <ImageView
-        android:id="@+id/artwork2"
-        android:layout_width="159dp"
-        android:layout_height="222dp"
-        android:layout_marginLeft="30dp"
-        android:layout_marginTop="85dp"
-        android:src="@drawable/davinciart" />
-</LinearLayout>
+            <ImageView
+                android:id="@+id/artwork1"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:layout_margin="8dp"
+                android:scaleType="centerCrop"
+                android:background="#CCCCCC" />
 
-<LinearLayout
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:orientation="horizontal">
-    <ImageView
-        android:id="@+id/artwork3"
-        android:layout_width="159dp"
-        android:layout_height="222dp"
-        android:layout_marginLeft="21dp"
-        android:layout_marginTop="10dp"
-        android:src="@drawable/mantegnaart" />
+            <ImageView
+                android:id="@+id/artwork2"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:layout_margin="8dp"
+                android:scaleType="centerCrop"
+                android:background="#CCCCCC" />
+        </LinearLayout>
 
-    <ImageView
-        android:id="@+id/artwork4"
-        android:layout_width="150dp"
-        android:layout_height="200dp"
-        android:layout_marginLeft="30dp"
-        android:layout_marginTop="15dp"
-        android:src="@drawable/emilart" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal"
+            android:gravity="center">
 
-</LinearLayout>
+            <ImageView
+                android:id="@+id/artwork3"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:layout_margin="8dp"
+                android:scaleType="centerCrop"
+                android:background="#CCCCCC" />
+
+            <ImageView
+                android:id="@+id/artwork4"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:layout_margin="8dp"
+                android:scaleType="centerCrop"
+                android:background="#CCCCCC" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- 다음 버튼 -->
     <Button
         android:id="@+id/next6"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="다음"
-        android:backgroundTint="#000000"
-        android:layout_marginTop="550dp"
-        android:layout_marginRight="15dp"
-        android:layout_marginLeft="15dp">
-    </Button>
+        android:textSize="16sp"
+        android:backgroundTint="@color/white"
+        android:textColor="@color/black"
+        android:layout_marginTop="24dp" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_mypage.xml
+++ b/app/src/main/res/layout/activity_mypage.xml
@@ -10,7 +10,7 @@
         android:layout_height="wrap_content"
         android:src="@drawable/setting"
         android:layout_marginLeft="330dp"
-        android:layout_marginTop="15dp" />
+        android:layout_marginTop="5dp" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -21,13 +21,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:src="@drawable/profile"
-            android:layout_marginTop="100dp" />
+            android:layout_marginTop="50dp" />
 
         <ImageView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:src="@drawable/profile2"
-            android:layout_marginTop="10dp" />
+            android:src="@drawable/profile2" />
 
         <LinearLayout
             android:id="@+id/main"
@@ -40,15 +39,15 @@
                 android:layout_height="wrap_content"
                 android:id="@+id/ticket"
                 android:src="@drawable/viewing"
-                android:layout_marginTop="20dp"
-                android:layout_marginLeft="20dp" />
+                android:layout_marginTop="10dp"
+                android:layout_marginLeft="15dp" />
 
             <ImageView
                 android:id="@+id/heart"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:src="@drawable/good"
-                android:layout_marginTop="20dp"
+                android:layout_marginTop="10dp"
                 android:layout_marginLeft="70dp" />
 
             <ImageView
@@ -56,8 +55,8 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:src="@drawable/chatting"
-                android:layout_marginTop="20dp"
-                android:layout_marginLeft="85dp" />
+                android:layout_marginTop="10dp"
+                android:layout_marginLeft="80dp" />
         </LinearLayout>
 
         <LinearLayout
@@ -70,7 +69,7 @@
                 android:layout_height="wrap_content"
                 android:text="관람 이력"
                 android:textStyle="bold"
-                android:layout_marginLeft="40dp" />
+                android:layout_marginLeft="35dp" />
 
             <TextView
                 android:layout_width="wrap_content"
@@ -84,18 +83,40 @@
                 android:layout_height="wrap_content"
                 android:text="채팅 이력"
                 android:textStyle="bold"
-                android:layout_marginLeft="65dp" />
+                android:layout_marginLeft="60dp" />
         </LinearLayout>
+
+        <TextView
+            android:layout_marginTop="10dp"
+            android:id="@+id/preferenceanalysis"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="취향 분석 시작하기"
+            android:gravity="center"
+            android:textColor="@color/black">
+        </TextView>
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:id="@+id/logout"
             android:text="로그아웃"
             android:gravity="center"
-            android:layout_marginTop="13dp"
+            android:layout_marginTop="8dp"
             android:textColor="#aaaaaa"
             android:textSize="13dp">
         </TextView>
+
+        <com.github.mikephil.charting.charts.PieChart
+            android:id="@+id/pieChart"
+            android:layout_width="match_parent"
+            android:layout_height="220dp"
+            android:layout_marginTop="5dp"
+            android:layout_marginBottom="80dp"
+            android:layout_below="@id/logout"
+            />
+
+
     </LinearLayout>
 
     <FrameLayout

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">192.168.0.173</domain>
+        <domain includeSubdomains="true">http://192.168.219.106:8000/</domain>
 <!--        <domain includeSubdomains="true">https://wasp-noble-seagull.ngrok-free.app/</domain>-->
     </domain-config>
 </network-security-config>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
+    id("com.android.application") version "8.6.0-alpha05" apply false
+    id("com.android.library") version "8.6.0-alpha05" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://jitpack.io") // jitpack.io: MPAndroidChart가 배포되는 저장소
     }
 }
 


### PR DESCRIPTION
<취향 분석 구현 진행 사항>
- 사용자가 작품 여러 개 선택 가능
- 장고 서버에서 지피티로 사조 분위기 추출
- 상위 5개의 태그로 안드로이드 원형 그래프 시각화
- 다른 페이지로 이동해도 이전 분석 결과 유지
(이어서 해야할 것)
전시회 목록에서 전시회 눌렀을 때 작품이 뜨는 게 구현된 이후
좋아요한 작품도 취향 분석 결과에 누적 반영되도록 확장할 예정